### PR TITLE
removed mutable default arguments

### DIFF
--- a/python/pfs/datamodel/pfsArm.py
+++ b/python/pfs/datamodel/pfsArm.py
@@ -291,13 +291,13 @@ class PfsArm(object):
 
 class PfsArmSet(object):
     """Manipulate a set of pfsArms corresponding to a single visit"""
-    def __init__(self, visit, spectrograph, arms=['b', 'r', 'n'], pfsConfigId=None, pfsConfig=None,
+    def __init__(self, visit, spectrograph, arms=None, pfsConfigId=None, pfsConfig=None,
                  pfsConfigs={}):
         self.pfsConfigs = pfsConfigs
         self.pfsConfigId = pfsConfigId
         self.visit = visit
         self.spectrograph = spectrograph
-        self.arms = arms
+        self.arms = arms if arms is not None else ['b', 'r', 'n']
 
         if pfsConfig:
             if self.pfsConfigId:

--- a/python/pfs/datamodel/pfsArm.py
+++ b/python/pfs/datamodel/pfsArm.py
@@ -291,13 +291,13 @@ class PfsArm(object):
 
 class PfsArmSet(object):
     """Manipulate a set of pfsArms corresponding to a single visit"""
-    def __init__(self, visit, spectrograph, arms=None, pfsConfigId=None, pfsConfig=None,
+    def __init__(self, visit, spectrograph, arms=('b', 'r', 'n'), pfsConfigId=None, pfsConfig=None,
                  pfsConfigs={}):
         self.pfsConfigs = pfsConfigs
         self.pfsConfigId = pfsConfigId
         self.visit = visit
         self.spectrograph = spectrograph
-        self.arms = arms if arms is not None else ['b', 'r', 'n']
+        self.arms = list(arms)
 
         if pfsConfig:
             if self.pfsConfigId:

--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -17,7 +17,7 @@ class PfsConfig(object):
 
     def __init__(self, pfsConfigId=None, tract=None, patch=None,
                  fiberId=None, ra=None, dec=None, catId=None, objId=None,
-                 fiberMag=None, mpsCen=None, filterNames=None):
+                 fiberMag=None, mpsCen=None, filterNames=("g", "r", "i", "z", "y")):
         self.pfsConfigId = pfsConfigId
         self.tract = tract
         self.patch = patch
@@ -28,7 +28,7 @@ class PfsConfig(object):
         self.catId = catId
         self.objId = objId
         self.fiberMag = fiberMag
-        self.filterNames = filterNames if filterNames is not None else ["g", "r", "i", "z", "y"]
+        self.filterNames = list(filterNames)
         self.mpsCen = mpsCen
 
         _pfsConfigId = calculate_pfsConfigId(self.fiberId, self.ra, self.dec)

--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -17,7 +17,7 @@ class PfsConfig(object):
 
     def __init__(self, pfsConfigId=None, tract=None, patch=None,
                  fiberId=None, ra=None, dec=None, catId=None, objId=None,
-                 fiberMag=None, mpsCen=None, filterNames=["g", "r", "i", "z", "y"]):
+                 fiberMag=None, mpsCen=None, filterNames=None):
         self.pfsConfigId = pfsConfigId
         self.tract = tract
         self.patch = patch
@@ -28,7 +28,7 @@ class PfsConfig(object):
         self.catId = catId
         self.objId = objId
         self.fiberMag = fiberMag
-        self.filterNames = filterNames
+        self.filterNames = filterNames if filterNames is not None else ["g", "r", "i", "z", "y"]
         self.mpsCen = mpsCen
 
         _pfsConfigId = calculate_pfsConfigId(self.fiberId, self.ra, self.dec)

--- a/python/pfs/datamodel/pfsFiberTrace.py
+++ b/python/pfs/datamodel/pfsFiberTrace.py
@@ -55,10 +55,10 @@ class PfsFiberTrace(object):
 
             # bboxAllTMI: BBox in allTracesMI
             bboxAllTMI = afwGeom.BoxI(afwGeom.PointI(x0, bbox.getMinY()), bbox.getDimensions())
-
+            
             trace = allTracesMI[bboxAllTMI].clone()
             trace.setXY0(bbox.getBegin())
-
+            
             self.traces.append(trace)
             x0 += bbox.getWidth()
 
@@ -129,7 +129,7 @@ class PfsFiberTrace(object):
         hdu.header["INHERIT"] = True
 
         # clobber=True in writeto prints a message, so use open instead
-
+        
         with pyfits.open(fullFileName, "update") as fd:
             fd[1].name = "IMAGE"
             fd[2].name = "MASK"

--- a/python/pfs/datamodel/pfsFiberTrace.py
+++ b/python/pfs/datamodel/pfsFiberTrace.py
@@ -55,10 +55,10 @@ class PfsFiberTrace(object):
 
             # bboxAllTMI: BBox in allTracesMI
             bboxAllTMI = afwGeom.BoxI(afwGeom.PointI(x0, bbox.getMinY()), bbox.getDimensions())
-            
+
             trace = allTracesMI[bboxAllTMI].clone()
             trace.setXY0(bbox.getBegin())
-            
+
             self.traces.append(trace)
             x0 += bbox.getWidth()
 
@@ -129,7 +129,7 @@ class PfsFiberTrace(object):
         hdu.header["INHERIT"] = True
 
         # clobber=True in writeto prints a message, so use open instead
-        
+
         with pyfits.open(fullFileName, "update") as fd:
             fd[1].name = "IMAGE"
             fd[2].name = "MASK"

--- a/python/pfs/datamodel/pfsObject.py
+++ b/python/pfs/datamodel/pfsObject.py
@@ -34,9 +34,9 @@ class PfsObject(object):
                 self.fluxVariance = np.zeros_like(lam)
                 self.mask = np.zeros_like(lam, dtype=np.int32)
 
-    def __init__(self, tract, patch, objId, catId=0, visits=[], pfsConfigIds=[],
+    def __init__(self, tract, patch, objId, catId=0, visits=None, pfsConfigIds=None,
                  nVisit=None, pfsVisitHash=0x0):
-        if visits:
+        if visits is not None:
             self.visits = visits
             self.nVisit = len(visits)
             self.pfsVisitHash = calculate_pfsVisitHash(visits)
@@ -52,10 +52,7 @@ class PfsObject(object):
             self.visits = None
             self.pfsVisitHash = pfsVisitHash
 
-        if pfsConfigIds:
-            self.pfsConfigIds = pfsConfigIds
-        else:
-            self.pfsConfigIds = None
+        self.pfsConfigIds = pfsConfigIds
 
         self.tract = tract
         self.patch = patch


### PR DESCRIPTION
Some method definitions use mutable as default values. As far as i can see, the "append" anti-pattern (https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html) is not wanted here.

This patch address this.