### PR TITLE
DAMD-61: changed file mode "w" to "wb"

### DIFF
--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -252,7 +252,7 @@ class PfsDesign:
         ], hdr, name='PHOTOMETRY'))
 
         # clobber=True in writeto prints a message, so use open instead
-        with open(filename, "w") as fd:
+        with open(filename, "wb") as fd:
             fits.writeto(fd)
 
     def write(self, dirName=".", fileName=None):

--- a/python/pfs/datamodel/pfsSpectra.py
+++ b/python/pfs/datamodel/pfsSpectra.py
@@ -205,7 +205,7 @@ class PfsSpectra:
             hduName = attr.upper()
             data = getattr(self, attr)
             fits.append(astropy.io.fits.ImageHDU(data, name=hduName))
-        with open(filename, "w") as fd:
+        with open(filename, "wb") as fd:
             fits.writeto(fd)
 
     def write(self, dirName="."):

--- a/python/pfs/datamodel/pfsSpectrum.py
+++ b/python/pfs/datamodel/pfsSpectrum.py
@@ -165,7 +165,7 @@ class PfsSimpleSpectrum:
         fits = HDUList()
         fits.append(PrimaryHDU())
         self._writeImpl(fits)
-        with open(filename, "w") as fd:
+        with open(filename, "wb") as fd:
             fits.writeto(fd)
 
     def write(self, dirName="."):


### PR DESCRIPTION
Changed open(..., "w") to open(..., "wb") for files that FITS data are
written on. Not only is it logically wrong to use the text mode here,
but it is also forbidden in astropy 3.2.