### PR TITLE
Corrected filenameFormat and filenameRegex for datamodel types

### DIFF
--- a/datamodel.txt
+++ b/datamodel.txt
@@ -18,7 +18,8 @@ NROW        The number of rows that spectra extend over in the dispersion direct
 	    In practice, the number of rows in the usable part of the CCD.
 NSIMROW     Number of rows for simulated data.  May be different in different files, depending
 	    on the desired oversampling.
-NCOARSE     Number of wavelengths used in computing the coarse (low-resolution) covariance matrix of the spectra
+NCOARSE     Number of wavelengths used in computing the coarse 
+      (low-resolution) covariance matrix of the spectra
 
 The values of NCOLUMN and NROW may be different in the optical and IR arms, and will differ for
 raw and reduced data.  Possible values are given in the section, "Parameters"
@@ -352,7 +353,8 @@ isn't human-friendly;  in particular it doesn't sort in a helpful way.  It seems
 ever have more than 1000 visits, but as the pfsVisitHash is unambiguous it seemed safer to only allow for
 larger values of nVisit, but record them only modulo 1000.
 
-     "pfsObject-%05d-%s-%03d-%016x-%03d-0x%016x.fits" % (tract, patch, catId, objId, nVisit % 1000, pfsVisitHash)
+     "pfsObject-%03d-%05d-%s-%016x-%03d-0x%016x.fits" 
+         % (catId, tract, patch, objId, nVisit % 1000, pfsVisitHash)
 
 The path would be
    tract/patch/pfsObject-*.fits
@@ -428,7 +430,7 @@ amplitude, width) for emission lines.  Will a continuum + lines model like this 
 evolution stellar spectra?
 
 For now, I propose:
-     "pfsSimObject-%05d-%s-%03d-%016x.fits" % (tract, patch, catId, objId)
+     "pfsSimObject-%03d-%05d-%s-%03d-%016x.fits" % (catId, tract, patch, objId)
 
 The tract, patch, catId, objId values will also be available as header keywords.
 
@@ -454,7 +456,8 @@ According to the "combined spectra" data model we include both the number of
 visits (nVisit) and a SHA-1 hash of the visits, pfsVisitHash.
 
 I propose :
-		"pfsZcandidates-%05d-%s-%03d-%016x-%03d-0x%016x.fits" % (tract, patch, catId, objId, nVisit % 1000, pfsVisitHash)
+		"pfsZcandidates-%03d-%05d-%s-%016x-%03d-0x%016x.fits" 
+        % (catId, tract, patch, objId, nVisit % 1000, pfsVisitHash)
 
 The path would be
    tract/patch/pfsZcandidate-*.fits
@@ -531,12 +534,12 @@ HDU#4 ZLINES                    Binary table            [FITS BINARY TABLE]     
  pfsPSF-000666-b1.fits
 	The 2-D PSF for spectrograph 1's blue arm in visit 666
 
- pfsObject-07621-2,2-001-02468ace1234abcd-003-0x1234abcddeadbeef.fits
+ pfsObject-001-07621-2,2-02468ace1234abcd-003-0x1234abcddeadbeef.fits
 	Combined spectrum for HSC (the "001") object 0x02468ace1234abcd, located in tract 7621, patch 2,2.
 
 	The pfsVisitHash SHA-1 (calculated from the 3 visits included in this reduction) is 0x1234abcddeadbeef.
 
- pfsSimObject-00000-0,0-000-13579bdf1234abcd.fits
+ pfsSimObject-000-00000-0,0-13579bdf1234abcd.fits
 	A simulated spectrum (the "000") for object 0x13579bdf1234abcd, located in tract 0, patch 0,0
 
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/python/pfs/datamodel/drp.py
+++ b/python/pfs/datamodel/drp.py
@@ -30,7 +30,7 @@ class PfsReference(PfsSimpleSpectrum):
     Produced by ``calculateReferenceFlux``.
     """
     filenameFormat = "pfsReference-%(catId)03d-%(tract)05d-%(patch)s-%(objId)016x.fits"
-    filenameRegex = r"^pfsReference-(\d{3})-(\d{5})-(.*)-(0x.{8})\.fits.*$"
+    filenameRegex = r"^pfsReference-(\d{3})-(\d{5})-(.*)-([0-9a-f]{16})\.fits.*$"
     filenameKeys = [("catId", int), ("tract", int), ("patch", str), ("objId", int)]
 
 
@@ -40,7 +40,7 @@ class PfsSingle(PfsSpectrum):
     Produced by ``fluxCalibrate``.
     """
     filenameFormat = "pfsSingle-%(catId)03d-%(tract)05d-%(patch)s-%(objId)016x-%(visit)06d.fits"
-    filenameRegex = r"^pfsSingle-(\d{3})-(\d{5})-(.*)-(0x.{16})-(\d{6})\.fits.*$"
+    filenameRegex = r"^pfsSingle-(\d{3})-(\d{5})-(.*)-([0-9a-f]{16})-(\d{6})\.fits.*$"
     filenameKeys = [("catId", int), ("tract", int), ("patch", str), ("objId", int), ("visit", int)]
 
 
@@ -49,7 +49,8 @@ class PfsObject(PfsSpectrum):
 
     Produced by ``coaddSpectra``.
     """
-    filenameFormat = "pfsObject-%(catId)03d-%(tract)05d-%(patch)s-%(objId)016x-%(nVisit)03d-%(pfsVisitHash)016x.fits"
-    filenameRegex = r"^pfsObject-(\d{3})-(\d{5})-(.*)-(0x.{16})-(\d{3})-(0x.{16})\.fits.*$"
+    filenameFormat = ("pfsObject-%(catId)03d-%(tract)05d-%(patch)s-%(objId)016x"
+                      "-%(nVisit)03d-0x%(pfsVisitHash)016x.fits")
+    filenameRegex = r"^pfsObject-(\d{3})-(\d{5})-(.*)-([0-9a-f]{16})-(\d{3})-0x([0-9a-f]{16})\.fits.*$"
     filenameKeys = [("catId", int), ("tract", int), ("patch", str), ("objId", int),
                     ("nVisit", int), ("pfsVisitHash", int)]

--- a/tests/test_FileFormats.py
+++ b/tests/test_FileFormats.py
@@ -1,0 +1,83 @@
+import unittest
+from pfs.datamodel.drp import PfsObject
+from pfs.datamodel.drp import PfsReference
+from pfs.datamodel.drp import PfsMerged
+from pfs.datamodel.drp import PfsSingle
+from pfs.datamodel.drp import PfsArm
+import re
+
+
+class FileFormatTestCase(unittest.TestCase):
+    """ Checks the format of example datamodel files are
+        consistent with that specified in the corresponding
+        datamodel classes.
+    """
+
+    def extractAttributes(self, cls, fileName):
+        matches = re.search(cls.filenameRegex, fileName)
+        if not matches:
+            self.fail(
+                "Unable to parse filename: {} using regex {}"
+                .format(fileName, cls.filenameRegex))
+
+        # Cannot use algorithm in PfsSpectra._parseFilename(),
+        # specifically cls.filenameKeys, due to ambiguity in parsing
+        # integers in hex format (eg objId). Need to parse cls.filenameFormat
+        ff = re.search(r'^[a-zA-Z]+(.*)\.fits', cls.filenameFormat)[1]
+        cmps = re.findall(r'-{0,1}(0x){0,1}\%\((\w+)\)\d*(\w)', ff)
+        fmts = [(kk, tt) for ox, kk, tt in cmps]
+
+        d = {}
+        for (kk, tt), vv in zip(fmts, matches.groups()):
+            if tt == 'd':
+                ii = int(vv)
+            elif tt == 'x':
+                ii = int(vv, 16)
+            elif tt == 's':
+                ii = vv
+            d[kk] = ii
+        return d
+
+    @unittest.expectedFailure
+    def testBadHashInFileName(self):
+        self.extractAttributes(
+            PfsObject,
+            'pfsObject-07621-2,2-001-02468ace1234abcd-003-1234abcddeadbeef.fits')
+
+    def testPfsArm(self):
+        d = self.extractAttributes(PfsArm, 'pfsArm-123450-b1.fits')
+        self.assertEqual(d['visit'], 123450)
+        self.assertEqual(d['arm'], 'b')
+        self.assertEqual(d['spectrograph'], 1)
+
+    def testPfsMerged(self):
+        d = self.extractAttributes(PfsMerged, 'pfsMerged-012345.fits')
+        self.assertEqual(d['visit'], 12345)
+
+    def testPfsReference(self):
+        d = self.extractAttributes(
+            PfsReference, 'pfsReference-001-07621-2,2-02468ace1234abcd.fits')
+        self.assertEqual(d['tract'], 7621)
+        self.assertEqual(d['patch'], '2,2')
+        self.assertEqual(d['catId'], 1)
+        self.assertEqual(d['objId'], 0x02468ace1234abcd)
+
+    def testPfsSingle(self):
+        d = self.extractAttributes(
+            PfsSingle, 'pfsSingle-123-76210-2,2-02468ace1234abcd-123450.fits')
+        self.assertEqual(d['tract'], 76210)
+        self.assertEqual(d['patch'], '2,2')
+        self.assertEqual(d['catId'], 123)
+        self.assertEqual(d['objId'], 0x02468ace1234abcd)
+        self.assertEqual(d['visit'], 123450)
+
+    def testPfsObject(self):
+        d = self.extractAttributes(
+            PfsObject,
+            'pfsObject-001-07621-2,2-02468ace1234abcd-003-0x1234abcddeadbeef.fits')
+        self.assertEqual(d['tract'], 7621)
+        self.assertEqual(d['patch'], '2,2')
+        self.assertEqual(d['objId'], 0x02468ace1234abcd)
+        self.assertEqual(d['catId'], 1)
+        self.assertEqual(d['nVisit'], 3)
+        self.assertEqual(d['pfsVisitHash'], 0x1234abcddeadbeef)


### PR DESCRIPTION
The filenameFormat and filenameRegex for the types PfsReference,
PfsSingle and PfsObject, in accordance with datamodel.txt.
Specifically the positioning of the 'catId' attribute has been
changed. Unit tests have been added to verify the fileformats.