### PR TITLE
Added new targetType category of BLACKSPOT.

### DIFF
--- a/datamodel.txt
+++ b/datamodel.txt
@@ -222,7 +222,7 @@ The DESIGN table lists for each object:
       objId          64-bit int
       ra             64-bit float (degrees)
       dec            64-bit float (degrees)
-      targetType     32-bit int (enumerated type: SCIENCE,SKY,FLUXSTD,BROKEN,BLOCKED)
+      targetType     32-bit int (enumerated type: SCIENCE,SKY,FLUXSTD,BROKEN,BLOCKED,BLACKSPOT)
       pfiNominal     pair of 32-bit floats (microns on the PFI)
 
 N.b. fiberIds start at 1.
@@ -269,7 +269,7 @@ The CONFIG table lists for each object:
       objId          64-bit int
       ra             64-bit float (degrees)
       dec            64-bit float (degrees)
-      targetType     32-bit int (enumerated type: SCIENCE,SKY,FLUXSTD,BROKEN,BLOCKED)
+      targetType     32-bit int (enumerated type: SCIENCE,SKY,FLUXSTD,BROKEN,BLOCKED,BLACKSPOT)
       pfiCenter      pair of 32-bit floats (microns on the PFI)
       pfiNominal     pair of 32-bit floats (microns on the PFI)
 

--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -10,6 +10,7 @@ except ImportError:
 
 __all__ = ["TargetType", "PfsDesign", "PfsConfig"]
 
+
 @enum.unique
 class TargetType(enum.IntEnum):
     """Enumerated options for what a fiber is targeting
@@ -20,7 +21,9 @@ class TargetType(enum.IntEnum):
     * ``FLUXSTD``: the fiber is intended to be on a flux standard, and used for
       flux calibration.
     * ``BROKEN``: the fiber is broken, and any flux should be ignored.
-    * ``BLOCKED``: the fiber is hidden behind its spot, and any flux should be
+    * ``BLOCKED``: the transmission through the fiber is temporarily blocked.
+        Any flux should be ignored. 
+    * ``BLACKSPOT``: the fiber is hidden behind its spot, and any flux should be
       ignored.
     """
     SCIENCE = 1
@@ -28,6 +31,7 @@ class TargetType(enum.IntEnum):
     FLUXSTD = 3
     BROKEN = 4
     BLOCKED = 5
+    BLACKSPOT = 6
 
 
 class PfsDesign:

--- a/tests/test_PfsConfig.py
+++ b/tests/test_PfsConfig.py
@@ -19,7 +19,9 @@ class PfsConfigTestCase(lsst.utils.tests.TestCase):
         self.numFluxStd = 300
         self.numBroken = 3
         self.numBlocked = 2
-        self.numObject = self.numFibers - (self.numSky + self.numFluxStd + self.numBroken + self.numBlocked)
+        self.numBlackSpot = 1
+        self.numObject = self.numFibers - (self.numSky + self.numFluxStd +
+                                           self.numBroken + self.numBlocked + self.numBlackSpot)
         self.raBoresight = 60.0*lsst.afw.geom.degrees
         self.decBoresight = 30.0*lsst.afw.geom.degrees
         self.fov = 1.5*lsst.afw.geom.degrees
@@ -53,6 +55,7 @@ class PfsConfigTestCase(lsst.utils.tests.TestCase):
                                    [int(TargetType.FLUXSTD)]*self.numFluxStd +
                                    [int(TargetType.BROKEN)]*self.numBroken +
                                    [int(TargetType.BLOCKED)]*self.numBlocked +
+                                   [int(TargetType.BLACKSPOT)]*self.numBlackSpot +
                                    [int(TargetType.SCIENCE)]*self.numObject)
         rng.shuffle(self.targetType)
 


### PR DESCRIPTION
This corresponds to situation where a fiber
is behind a spot on the PFI.
Changed description of category BLOCKED to now read
a temporary blockage of flux transmission.
Updated datamodel.txt, TargetType class and unit test.