### PR TITLE
DAMD-87: Updated drp.py to accommodate 5-digit catId

### DIFF
--- a/python/pfs/datamodel/drp.py
+++ b/python/pfs/datamodel/drp.py
@@ -34,8 +34,8 @@ class PfsReference(PfsSimpleSpectrum):
 
     Produced by ``calculateReferenceFlux``.
     """
-    filenameFormat = "pfsReference-%(catId)03d-%(tract)05d-%(patch)s-%(objId)016x.fits"
-    filenameRegex = r"^pfsReference-(\d{3})-(\d{5})-(.*)-([0-9a-f]{16})\.fits.*$"
+    filenameFormat = "pfsReference-%(catId)05d-%(tract)05d-%(patch)s-%(objId)016x.fits"
+    filenameRegex = r"^pfsReference-(\d{5})-(\d{5})-(.*)-([0-9a-f]{16})\.fits.*$"
     filenameKeys = [("catId", int), ("tract", int), ("patch", str), ("objId", int)]
 
 
@@ -45,8 +45,8 @@ class PfsSingle(PfsFiberArray):
 
     Produced by ``fluxCalibrate``.
     """
-    filenameFormat = "pfsSingle-%(catId)03d-%(tract)05d-%(patch)s-%(objId)016x-%(visit)06d.fits"
-    filenameRegex = r"^pfsSingle-(\d{3})-(\d{5})-(.*)-([0-9a-f]{16})-(\d{6})\.fits.*$"
+    filenameFormat = "pfsSingle-%(catId)05d-%(tract)05d-%(patch)s-%(objId)016x-%(visit)06d.fits"
+    filenameRegex = r"^pfsSingle-(\d{5})-(\d{5})-(.*)-([0-9a-f]{16})-(\d{6})\.fits.*$"
     filenameKeys = [("catId", int), ("tract", int), ("patch", str), ("objId", int), ("visit", int)]
 
 
@@ -56,8 +56,8 @@ class PfsObject(PfsFiberArray):
 
     Produced by ``coaddSpectra``.
     """
-    filenameFormat = ("pfsObject-%(catId)03d-%(tract)05d-%(patch)s-%(objId)016x"
+    filenameFormat = ("pfsObject-%(catId)05d-%(tract)05d-%(patch)s-%(objId)016x"
                       "-%(nVisit)03d-0x%(pfsVisitHash)016x.fits")
-    filenameRegex = r"^pfsObject-(\d{3})-(\d{5})-(.*)-([0-9a-f]{16})-(\d{3})-0x([0-9a-f]{16})\.fits.*$"
+    filenameRegex = r"^pfsObject-(\d{5})-(\d{5})-(.*)-([0-9a-f]{16})-(\d{3})-0x([0-9a-f]{16})\.fits.*$"
     filenameKeys = [("catId", int), ("tract", int), ("patch", str), ("objId", int),
                     ("nVisit", int), ("pfsVisitHash", int)]

--- a/tests/test_FileFormats.py
+++ b/tests/test_FileFormats.py
@@ -56,28 +56,28 @@ class FileFormatTestCase(unittest.TestCase):
 
     def testPfsReference(self):
         d = self.extractAttributes(
-            PfsReference, 'pfsReference-001-07621-2,2-02468ace1234abcd.fits')
+            PfsReference, 'pfsReference-00100-07621-2,2-02468ace1234abcd.fits')
         self.assertEqual(d['tract'], 7621)
         self.assertEqual(d['patch'], '2,2')
-        self.assertEqual(d['catId'], 1)
+        self.assertEqual(d['catId'], 100)
         self.assertEqual(d['objId'], 0x02468ace1234abcd)
 
     def testPfsSingle(self):
         d = self.extractAttributes(
-            PfsSingle, 'pfsSingle-123-76210-2,2-02468ace1234abcd-123450.fits')
+            PfsSingle, 'pfsSingle-12300-76210-2,2-02468ace1234abcd-123450.fits')
         self.assertEqual(d['tract'], 76210)
         self.assertEqual(d['patch'], '2,2')
-        self.assertEqual(d['catId'], 123)
+        self.assertEqual(d['catId'], 12300)
         self.assertEqual(d['objId'], 0x02468ace1234abcd)
         self.assertEqual(d['visit'], 123450)
 
     def testPfsObject(self):
         d = self.extractAttributes(
             PfsObject,
-            'pfsObject-001-07621-2,2-02468ace1234abcd-003-0x1234abcddeadbeef.fits')
+            'pfsObject-12345-07621-2,2-02468ace1234abcd-003-0x1234abcddeadbeef.fits')
         self.assertEqual(d['tract'], 7621)
         self.assertEqual(d['patch'], '2,2')
         self.assertEqual(d['objId'], 0x02468ace1234abcd)
-        self.assertEqual(d['catId'], 1)
+        self.assertEqual(d['catId'], 12345)
         self.assertEqual(d['nVisit'], 3)
         self.assertEqual(d['pfsVisitHash'], 0x1234abcddeadbeef)


### PR DESCRIPTION
The above file and corresponding unit test were not updated
following the DAMD-86 change, as drp.py is not
used by other parts of the 2D DRP, but as part of the public
API can be used by other developers.