### PR TITLE
DAMD-102: Revert lsst log dependency

### DIFF
--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -1,7 +1,6 @@
 import numpy as np
 import os
 import enum
-import lsst.log
 
 try:
     import astropy.io.fits as pyfits
@@ -10,8 +9,6 @@ except ImportError:
 
 
 __all__ = ("TargetType", "FiberStatus", "PfsDesign", "PfsConfig")
-
-logger = lsst.log.Log.getLogger("pfs.datamodel.pfsConfig")
 
 
 class DocEnum(enum.IntEnum):
@@ -728,7 +725,6 @@ class PfsConfig(PfsDesign):
             Constructed `PfsConfig`.
         """
         filename = os.path.join(dirName, cls.fileNameFormat % (pfsDesignId, visit0))
-        logger.debugf('Reading file {}', filename)
         return cls._readImpl(filename, pfsDesignId=pfsDesignId, visit0=visit0)
 
     def extractCenters(self, fiberId):


### PR DESCRIPTION
This reverts commit b25423b4a5d8293e1c13d8a9ca4504a34b967aaa.

This commit introduces a dependency on ``lsst.log`` that causes problems for the 1D DRP developers.
The related logging messages are no longer required.