### PR TITLE
PIPE2D-849: pfsConfig: add selection by spectrograph number

### DIFF
--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -523,7 +523,8 @@ class PfsDesign:
         self._writeImpl(os.path.join(dirName, fileName))
 
     def getSelection(self, fiberId=None, targetType=None, fiberStatus=None,
-                     catId=None, tract=None, patch=None, objId=None):
+                     catId=None, tract=None, patch=None, objId=None,
+                     spectrograph=None):
         """Return a boolean array indicating which fibers are selected
 
         Multiple attributes will be combined with ``AND``.
@@ -544,6 +545,8 @@ class PfsDesign:
             Patch name to select.
         objId : `int` (scalar or array_like), optional
             Object identifier to select.
+        spectrograph : `int` (scalar or array_like), optional
+            Spectrograph to select.
 
         Returns
         -------
@@ -565,6 +568,8 @@ class PfsDesign:
             selection &= np.isin(self.patch, patch)
         if objId is not None:
             selection &= np.isin(self.objId, objId)
+        if spectrograph is not None:
+            selection &= np.isin(self.spectrograph, spectrograph)
         return selection
 
     def select(self, **kwargs):

--- a/python/pfs/datamodel/pfsFiberArraySet.py
+++ b/python/pfs/datamodel/pfsFiberArraySet.py
@@ -142,6 +142,8 @@ class PfsFiberArraySet:
             Patch name to select.
         objId : `int` (scalar or array_like), optional
             Object identifier to select.
+        spectrograph : `int` (scalar or array_like), optional
+            Spectrograph number to select.
 
         Returns
         -------


### PR DESCRIPTION
This allows us to quickly weed out fibers that are in spectrographs other
than the one we care about.