### PR TITLE
DAMD-126: Explicitly specify the allowed range for the AG camera ID (agId)

### DIFF
--- a/datamodel.txt
+++ b/datamodel.txt
@@ -406,7 +406,8 @@ Where the:
     * magnitude is the magnitude for the guide star
     * passband is the passband over which the magnitude is measured.
     * color is the Gaia broadband BP-RP color for that guide star.
-    * agId is the identifier for the AG camera that will observe that guide star
+    * agId is the identifier for the AG camera that will observe that guide star.
+        This can have a value from 0 to 5 inclusive.
     * agX is the X-position on the corresponding AG camera where the guide star
           is expected to be detected
     * agY is the Y-position on the corresponding AG camera where the guide star

--- a/python/pfs/datamodel/guideStars.py
+++ b/python/pfs/datamodel/guideStars.py
@@ -36,7 +36,7 @@ class GuideStars:
         Gaia broadband BP-RP color for each guide star.
     agId : `numpy.ndarray` of `int32`
         Identifier for the AG camera that is expected to detect
-        the corresponding guide star.
+        the corresponding guide star. This can have a value from 0 to 5 inclusive.
     agX : `numpy.ndarray' of `float32`
         The expected x-position of the guide star on the
         appropriate AG camera, pixels.


### PR DESCRIPTION
This will be zero-based, so have a range between 0 and 5 inclusive.