### PR TITLE
fix a typo

### DIFF
--- a/datamodel.txt
+++ b/datamodel.txt
@@ -299,7 +299,7 @@ HDU #3          FITS binary table named "GUIDESTARS"
 
 The PDU contains the following keys:
 
-      DSGN_NAME Human-readable name for the design
+      DSGN_NAM  Human-readable name for the design
       RA        Intended telescope boresight Right Ascension (degrees)
       DEC       Intended telescope boresight Declination (degrees)
       POSANG    Intended Position Angle of the PFI (degrees).


### PR DESCRIPTION
The actual keyword for `Human-readable name for the design` of pfsDesign is `DSGN_NAM` instead of `DSGN_NAME`.

(It might be the implementation that should be fixed.)

```
[michitaro@obslog-ics pfsDesign]$ ls -l pfsDesign-0x66d10a1062719d1a.fits
-rw-rw-r--. 1 kiyoyabe naoj 417600 May 18 16:50 pfsDesign-0x66d10a1062719d1a.fits
```

```
[michitaro@obslog-ics pfsDesign]$ fold pfsDesign-0x66d10a1062719d1a.fits | head -36 | grep -i design
DSGN_NAM= '' / Name of design
```