### PR TITLE
DAMD-136 Add support for reading GuideStar objIds as 64-bit

### DIFF
--- a/python/pfs/datamodel/guideStars.py
+++ b/python/pfs/datamodel/guideStars.py
@@ -174,7 +174,7 @@ class GuideStars:
         """
         hdu = fits[cls._hduName]
 
-        return cls(hdu.data["objId"].astype(np.int32),
+        return cls(hdu.data["objId"].astype(np.int64),
                    hdu.data["epoch"],
                    hdu.data["ra"].astype(np.float64),
                    hdu.data["dec"].astype(np.float64),

--- a/tests/test_GuideStars.py
+++ b/tests/test_GuideStars.py
@@ -1,4 +1,7 @@
 import numpy as np
+import sys
+import unittest
+from astropy.io.fits import HDUList
 
 import lsst.utils.tests
 
@@ -52,6 +55,31 @@ class GuideStarsTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(gs.agY, self.agY, rtol=3.4e-8, atol=3.4e-8)
         self.assertFloatsAlmostEqual(gs.telElev, self.telElev, rtol=3.4e-8, atol=3.4e-8)
         self.assertEqual(gs.guideStarCatId, self.guideStarCatId)
+
+    def testFitsLargeObjId(self):
+        """Tests that objIds of value > 2^32 are not truncated"""
+        fits = HDUList()
+        objId0 = 0x20000000000  # 2^41
+        objId1 = 0x100  # 2^8
+        gsLocal = GuideStars(np.array([objId0, objId1], dtype=np.int64),
+                             np.array(['J2015.5', 'B1950.0'], dtype='a7'),
+                             np.array([1.0, 2.0], dtype=np.float64),
+                             np.array([1.0, 3.0], dtype=np.float64),
+                             np.array([1.0, 4.0], dtype=np.float32),
+                             np.array([1.0, 10], dtype=np.float32),
+                             np.array([1.0, 15], dtype=np.float32),
+                             np.array([1.0, 10], dtype=np.float32),
+                             np.array(['g', 'r'], dtype='a1'),
+                             np.array([1.0, 1.0], dtype=np.float32),
+                             np.array([456, 123], dtype=np.int32),
+                             np.array([1.0, 100.0], dtype=np.float32),
+                             np.array([1.0, 5.0], dtype=np.float32),
+                             0.0,
+                             0.0)
+
+        gsLocal.toFits(fits)
+        gsIn = GuideStars.fromFits(fits)
+        self.assertEqual(gsIn.objId.tolist(), gsLocal.objId.tolist())
 
     def testBasic(self):
         """Test basic functions"""
@@ -127,7 +155,6 @@ class GuideStarsTestCase(lsst.utils.tests.TestCase):
 
     def testFits(self):
         """Test I/O with FITS"""
-        from astropy.io.fits import HDUList
         fits = HDUList()
         self.guideStars.toFits(fits)
         gs = GuideStars.fromFits(fits)
@@ -136,3 +163,8 @@ class GuideStarsTestCase(lsst.utils.tests.TestCase):
 
 def setup_module(module):
     lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    setup_module(sys.modules["__main__"])
+    unittest.main()


### PR DESCRIPTION
Also added code to allow unit test to run standalone for testing.