### PR TITLE
PIPE2D-1362: Add PfsFluxCalib

### DIFF
--- a/datamodel.txt
+++ b/datamodel.txt
@@ -755,6 +755,28 @@ The particular representation used is written in the PHDU as the value of the
     coeffs          64-bit float array
     rms             64-bit float
 
+* PfsFluxCalib: Flux calibration vector: h(lam) exp g(x,y,lam), where h(lam)
+  is PfsConstantFocalPlaneFunction, and g(x,y,lam) is a polynomial.
+  The FITS file includes the same HDUs as PfsConstantFocalPlaneFunction does,
+  plus a binary table HDU named "POLYNOMIAL" defining g(x,y,lam). The last
+  table has only a single row with the following columns:
+
+    params          64-bit float array, length combination(order+3, 3)
+    min             64-bit float array, length 3.
+    max             64-bit float array, length 3.
+
+  params[i] is the coefficient by which to multiply the term
+  x^e[i][0] y^e[i][1] lam^e[i][2]. "e", array of 3-tuple of exponents, is
+  in descending order of e[.][0] + e[.][1] + e[.][2]. Ties are broken in
+  the reverse order of 3-tuple. For example, e = [(2,0,0),(1,1,0),(1,0,1),
+  (0,2,0),(0,1,1),(0,0,2),(1,0,0),(0,1,0),(0,0,1),(0,0,0)] if order=2.
+
+  min (max) is the vertex of the rectangular-parallelepipedal domain of the
+  polynomial at which (x, y, lam) are minimal (maximal). Arguments of the
+  polynomial are normalized so that min will be mapped to (0, 0, 0) and max
+  to (1, 1, 1). This nomalization happens before the arguments are
+  substituted for the variables of the polynomial.
+
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 The PSF for a single exposure


### PR DESCRIPTION
`PfsFluxCalib` is a subclass of `PfsFocalPlaneFunction`. This class is used by fitFluxCal.py in drp_stella.