### PR TITLE
PIPE2D-1668: Make InstrumentStatusFlag compatible with python 3.9

### DIFF
--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -153,8 +153,21 @@ class FiberStatus(DocEnum):
     NOTCONVERGED = 7, "Cobra did not converge to the target."
 
 
-@enum.verify(enum.UNIQUE)
-class InstrumentStatusFlag(enum.IntFlag, boundary=enum.STRICT):
+try:
+    def verify(*args, **kwargs):
+        return enum.verify(enum.UNIQUE)(*args, **kwargs)
+    metaclassParams = dict(boundary=enum.STRICT)
+except AttributeError:
+    # enum.verify etc was added in python 3.11; add a no-op version for earlier versions
+    metaclassParams = {}
+
+    def verify(cls):
+        """No-op version of enum.verify"""
+        return cls
+
+
+@verify
+class InstrumentStatusFlag(enum.IntFlag, **metaclassParams):
     """Bit positions for instrument status flags."""
     INSROT_MISMATCH = 1 << 0
 


### PR DESCRIPTION
enum.verify etc were added in python 3.11, but we need to be able to run with python 3.9. Added no-op version.