### PR TITLE
DAMD-180: Add a new TargetType SCIENCE_MASKED

### DIFF
--- a/datamodel.txt
+++ b/datamodel.txt
@@ -498,6 +498,7 @@ The 'targetType' in the DESIGN table is an enumerated type, with values:
     HOME = 9: Cobra is going to its home position.
     BLACKSPOT = 10: Cobra is going behind the black spot.
     AFL = 11: The fiber is fed by all fiber lamp cable.
+    SCIENCE_MASKED = 12: The fiber is on a science target redacted for privacy.
 
 The 'fiberStatus' in the DESIGN table is an enumerated type, with values:
     GOOD = 1: The fiber is working normally.

--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -142,6 +142,7 @@ class TargetType(DocEnum):
     HOME = 9, "cobra is going to home position"
     BLACKSPOT = 10, "cobra is going to black spot position"
     AFL = 11, "fiber goes to all fiber lamp"
+    SCIENCE_MASKED = 12, "science target redacted for privacy"
 
 
 class FiberStatus(DocEnum):


### PR DESCRIPTION
Before a pfsConfig is sent to open-use PIs, it will be modified so that the other PIs' targets will be replaced with nonsense numbers. The 2D pipeline must ignore these masked targets when the PIs run it for themselves. We expect the 2D pipeline will ignore targets that are not "SCIENCE". We therefore introduce a new TargetType SCIENCE_MASKED indicating "The target is redacted for privacy."