### PR TITLE
Tickets/damd 181

### DIFF
--- a/bin/testPfsTargetSpectraPartialIO.py
+++ b/bin/testPfsTargetSpectraPartialIO.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import os
+from time import time
+import resource
+from argparse import ArgumentParser
+from pfs.datamodel import PfsCalibrated
+
+
+def get_bytes_read(pid):
+    """Return the number of bytes read so far for the given process ID."""
+
+    with open(f"/proc/{pid}/io", "r") as f:
+        for line in f:
+            if line.startswith("rchar:"):
+                return int(line.split()[1])
+
+    return 0
+
+
+def main(filename, **kwargs):
+    # Remove None values from kwargs
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+    # Get the PID of the current process
+    pid = os.getpid()
+
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    bytes_start = get_bytes_read(pid)
+    time_start = time()
+    print('Bytes read so far:', bytes_start)
+    print('Max RSS:', usage.ru_maxrss, 'kB')
+    print('Minor page faults so far:', usage.ru_minflt)
+    print('Major page faults so far:', usage.ru_majflt)
+
+    # Load a subset of the spectra
+    spectra = PfsCalibrated.readFits(filename, **kwargs)
+    print(f"Loaded {len(spectra)} spectra with kwargs: {kwargs}")
+
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    bytes_partial = get_bytes_read(pid)
+    time_partial = time()
+    print('Bytes read during loading:', bytes_partial - bytes_start)
+    print('Time taken to load a subset of spectra:', time_partial - time_start)
+    print('Max RSS:', usage.ru_maxrss, 'kB')
+    print('Minor page faults so far:', usage.ru_minflt)
+    print('Major page faults so far:', usage.ru_majflt)
+
+    # Load the entire file
+    spectra = PfsCalibrated.readFits(filename)
+    print(f"Loaded {len(spectra)} spectra.")
+
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    bytes_all = get_bytes_read(pid)
+    time_all = time()
+    print('Bytes read during loading:', bytes_all - bytes_partial)
+    print('Time taken to load all spectra:', time_all - time_partial)
+    print('Max RSS:', usage.ru_maxrss, 'kB')
+    print('Minor page faults so far:', usage.ru_minflt)
+    print('Major page faults so far:', usage.ru_majflt)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="""
+Transitioning to gen3 Butler resulted in combining target spectra into large FITS files which
+contain many PfsSingle or PfsObject spectra. This script can be used to benchmark the IO cost
+saved by partially loading PfsCalibrated or PfsCoadd spectra, rather than loading the
+entire file.
+""")
+    parser.add_argument("filename", help="Name of the file to load.")
+    parser.add_argument("--targetId", type=int, help="Target IDs to load (default: all).")
+    parser.add_argument("--targetType", type=int, help="TargetType to load (default: all).")
+    parser.add_argument("--catId", type=int, help="Objects with catId to load (default: all).")
+    args = parser.parse_args()
+    main(args.filename,
+         targetId=args.targetId)

--- a/python/pfs/datamodel/pfsTargetSpectra.py
+++ b/python/pfs/datamodel/pfsTargetSpectra.py
@@ -164,14 +164,17 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
                         # Different for each spectrum, such as flux, do filter
                         return hdu.data[mask].astype(dtype)
             elif isinstance(hdu, BinTableHDU):
-                # This is a special case of storing arrays in a table.
-                # Rows of the arrays are stored as columns of a table.
+                # This is a special case of storing variable length arrays in a table.
+                # Rows of 2D arrays are stored as columns of a table (e.g. covariance)
                 numRows = len(hdu.data.dtype)
                 if numRows == 1:
-                    # Single row, such as wavelength fixed wavelength
-                    return [row["value"].astype(dtype) for row in hdu.data]
+                    # 1D array stored as a single column
+                    if mask is None:
+                        return [row["value"].astype(dtype) for row in hdu.data]
+                    else:
+                        return [row.astype(dtype) for row in hdu.data["value"][mask]]
                 else:
-                    # One row per spectrum, such as flux
+                    # 2D array stored as multiple columns
                     data: List[np.ndarray] = []
                     if mask is not None:
                         index = np.where(mask)[0]

--- a/python/pfs/datamodel/pfsTargetSpectra.py
+++ b/python/pfs/datamodel/pfsTargetSpectra.py
@@ -116,13 +116,18 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
         return target in self.spectra
 
     @classmethod
-    def readFits(cls, filename: str) -> "PfsTargetSpectra":
-        """Read from FITS file
+    def readFits(cls, filename: str, **kwargs) -> "PfsTargetSpectra":
+        """Read a collection of spectra from a FITS file, optionally
+        filtered by keyword arguments.
 
         Parameters
         ----------
         filename : `str`
             Filename of FITS file.
+        **kwargs : `dict`
+            Keyword arguments to filter the spectra. The keys supported depend on the
+            subclass of `PfsTargetSpectra`. For example, the `PfsFiberArray` class supports
+            filtering by `targetType`, `catId`, and `objId`.
 
         Returns
         -------
@@ -130,7 +135,7 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
             Constructed instance, from FITS file.
         """
 
-        def readData(hduName: str, dtype: type) -> Union[np.ndarray, List[np.ndarray]]:
+        def readData(hduName: str, dtype: type, mask=None) -> Union[np.ndarray, List[np.ndarray]]:
             """Read data from FITS file
 
             Parameters
@@ -139,6 +144,8 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
                 Name of the HDU.
             dtype : `type`
                 Data type.
+            mask : `np.ndarray`, optional
+                Mask to apply to the data. If provided, the data will be read as a masked array.
 
             Returns
             -------
@@ -147,33 +154,72 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
             """
             hdu = fits[hduName]
             if isinstance(hdu, (ImageHDU, CompImageHDU)):
-                return hdu.data.astype(dtype)
-            numRows = len(hdu.data.dtype)
-            if numRows == 1:
-                return [row["value"].astype(dtype) for row in hdu.data]
-            data: List[np.ndarray] = []
-            for ii in range(len(hdu.data)):
-                data.append(np.array([hdu.data[f"row_{jj}"][ii] for jj in range(numRows)], dtype=dtype))
-            return data
+                if mask is None:
+                    return hdu.data.astype(dtype)
+                else:
+                    if hdu.data.ndim == 1:
+                        # Same for all spectra, such as wavelength, do not filter
+                        return hdu.data.astype(dtype)
+                    else:
+                        # Different for each spectrum, such as flux, do filter
+                        return hdu.data[mask].astype(dtype)
+            elif isinstance(hdu, BinTableHDU):
+                # This is a special case of storing arrays in a table.
+                # Rows of the arrays are stored as columns of a table.
+                numRows = len(hdu.data.dtype)
+                if numRows == 1:
+                    # Single row, such as wavelength fixed wavelength
+                    return [row["value"].astype(dtype) for row in hdu.data]
+                else:
+                    # One row per spectrum, such as flux
+                    data: List[np.ndarray] = []
+                    if mask is not None:
+                        index = np.where(mask)[0]
+                    else:
+                        index = range(len(hdu.data))
+
+                    for ii in index:
+                        data.append(np.array(
+                            [hdu.data[f"row_{jj}"][ii] for jj in range(numRows)],
+                            dtype=dtype))
+
+                    return data
+            else:
+                raise TypeError(f"HDU '{hduName}' is not an ImageHDU, CompImageHDU or BinTableHDU.")
 
         spectra = []
         with astropy.io.fits.open(filename) as fits:
+            # Read the main headers and the list of targets.
             header = fits[0].header
             targetHdu = fits["TARGET"].data
+
+            # If any keyword arguments are provided, filter the spectra
+            mask = None
+            for key, value in kwargs.items():
+                if key not in targetHdu.columns.names:
+                    raise KeyError(f"Keyword argument '{key}' not found in TARGET HDU.")
+                m = targetHdu[key] == value
+                mask = m if mask is None else mask & m
+
             targetFluxHdu = fits["TARGETFLUX"].data
             observationsHdu = fits["OBSERVATIONS"].data
-            wavelengthData = readData("WAVELENGTH", np.float64)
-            fluxData = readData("FLUX", np.float32)
-            maskData = readData("MASK", np.int32)
-            skyData = readData("SKY", np.float32)
-            covarData = readData("COVAR", np.float32)
-            covar2Hdu = fits["COVAR2"].data if "COVAR2" in fits else None
+            wavelengthData = readData("WAVELENGTH", np.float64, mask=mask)
+            fluxData = readData("FLUX", np.float32, mask=mask)
+            maskData = readData("MASK", np.int32, mask=mask)
+            skyData = readData("SKY", np.float32, mask=mask)
+            covarData = readData("COVAR", np.float32, mask=mask)
+            covar2Data = readData("COVAR2", np.float32, mask=mask) if "COVAR2" in fits else None
             metadataHdu = fits["METADATA"].data
             fluxTableHdu = fits["FLUXTABLE"].data
             notesTable = cls.NotesClass.readHdu(fits)
 
-            for ii, row in enumerate(targetHdu):
-                targetId = row["targetId"]
+            if mask is None:
+                targets = enumerate(targetHdu.targetId)
+            else:
+                targets = zip(np.where(mask)[0], targetHdu.targetId[mask])
+
+            for ii, (index, targetId) in enumerate(targets):
+                row = targetHdu[index]
                 select = targetFluxHdu.targetId == targetId
                 fiberFlux = dict(
                     zip(
@@ -203,7 +249,7 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
                     observationsHdu.pfiCenter[select],
                 )
 
-                metadataRow = metadataHdu[ii]
+                metadataRow = metadataHdu[index]
                 assert metadataRow["targetId"] == targetId
 
                 metadata = yaml.load(
@@ -213,7 +259,7 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
                 )
                 flags = MaskHelper.fromFitsHeader(metadata, strip=True)
 
-                fluxTableRow = fluxTableHdu[ii]
+                fluxTableRow = fluxTableHdu[index]
                 assert fluxTableRow["targetId"] == targetId
                 fluxTable = FluxTable(
                     fluxTableRow["wavelength"],
@@ -224,7 +270,7 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
                 )
 
                 notes = cls.PfsFiberArrayClass.NotesClass(
-                    **{col.name: getattr(notesTable, col.name)[ii] for col in notesTable.schema}
+                    **{col.name: getattr(notesTable, col.name)[index] for col in notesTable.schema}
                 )
 
                 # Wavelength: we might write a single array if everything has the same length and value
@@ -242,7 +288,7 @@ class PfsTargetSpectra(Mapping[Target, PfsFiberArray]):
                     maskData[ii],
                     skyData[ii],
                     covarData[ii],
-                    covar2Hdu[ii] if covar2Hdu is not None else [],
+                    covar2Data[ii] if covar2Data is not None else [],
                     flags,
                     metadata,
                     fluxTable,

--- a/tests/test_PfsTargetSpectra.py
+++ b/tests/test_PfsTargetSpectra.py
@@ -363,12 +363,19 @@ class PfsTargetSpectraTestCase(lsst.utils.tests.TestCase):
     def testIOWithFilters(self):
         """Test I/O functionality with filters"""
 
-        spectra = self.makePfsTargetSpectra(list(range(123)))
+        spectra = self.makePfsTargetSpectra(list(range(123)), catId=itertools.cycle([12345, 12346, 12347]))
         with lsst.utils.tests.getTempFilePath(".fits") as filename:
             spectra.writeFits(filename)
 
+            # Filter single spectrum by objId
             copy = PfsCoadd.readFits(filename, objId=22)
             self.assertPfsTargetSpectraEqual(copy, PfsCoadd([spectra[22]]))
+
+            # Filter multiple spectra by catId
+            copy = PfsCoadd.readFits(filename, catId=12345)
+            for (_, left), right in zip(copy.items(), [s for t, s in spectra.items() if t.catId == 12345]):
+                self.assertTargetEqual(left.target, right.target)
+                self.assertPfsFiberArrayEqual(left, right)
 
     def testDifferentLengths(self):
         """Test I/O when the spectra have different lengths"""
@@ -377,6 +384,30 @@ class PfsTargetSpectraTestCase(lsst.utils.tests.TestCase):
             spectra.writeFits(filename)
             copy = PfsCoadd.readFits(filename)
             self.assertPfsTargetSpectraEqual(copy, spectra)
+
+    def testDifferentLengthsWithFilters(self):
+        """Test I/O when the spectra have different lengths and filters are used"""
+        spectra = self.makePfsTargetSpectra(
+            list(range(123)),
+            catId=itertools.cycle([12345, 12346, 12347]),
+            length=itertools.cycle([999, 1000, 1001, 1002, 1003])
+        )
+        with lsst.utils.tests.getTempFilePath(".fits") as filename:
+            spectra.writeFits(filename)
+
+            # Filter single spectrum by objId
+            for ii in range(22, 27):
+                copy = PfsCoadd.readFits(filename, objId=ii)
+                self.assertPfsTargetSpectraEqual(copy, PfsCoadd([spectra[ii]]))
+
+            # Filter multiple spectra by catId
+            copy = PfsCoadd.readFits(filename, catId=12345)
+            for (_, left), right in zip(
+                    copy.items(),
+                    [s for t, s in spectra.items() if t.catId == 12345]):
+
+                self.assertTargetEqual(left.target, right.target)
+                self.assertPfsFiberArrayEqual(left, right)
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_PfsTargetSpectra.py
+++ b/tests/test_PfsTargetSpectra.py
@@ -349,6 +349,7 @@ class PfsTargetSpectraTestCase(lsst.utils.tests.TestCase):
 
     def testIO(self):
         """Test I/O functionality"""
+
         spectra = self.makePfsTargetSpectra(list(range(123)))
         with lsst.utils.tests.getTempFilePath(".fits") as filename:
             spectra.writeFits(filename)
@@ -358,6 +359,16 @@ class PfsTargetSpectraTestCase(lsst.utils.tests.TestCase):
             # Check that the DAMD_VER is present
             with astropy.io.fits.open(filename) as hdus:
                 self.assertIn("DAMD_VER", hdus[0].header)
+
+    def testIOWithFilters(self):
+        """Test I/O functionality with filters"""
+
+        spectra = self.makePfsTargetSpectra(list(range(123)))
+        with lsst.utils.tests.getTempFilePath(".fits") as filename:
+            spectra.writeFits(filename)
+
+            copy = PfsCoadd.readFits(filename, objId=22)
+            self.assertPfsTargetSpectraEqual(copy, PfsCoadd([spectra[22]]))
 
     def testDifferentLengths(self):
         """Test I/O when the spectra have different lengths"""


### PR DESCRIPTION
I've added a feature to only load a single spectrum or a subset of spectra from PfsTargetSpectra (PfsCalibrated, PfsCoadd). By specifying keywords that refer to columns in the TARGET HDU, spectra can be filtered, e.g. 

```
PfsCoadd.readFits(filename, catId=12345)
```

It's hard to tell how much impact it has it on IO performance. I was hoping to make it much faster to load a single spectrum instead of loading all the spectra from the file but since the FITS file is memory-mapped, it's not so straightforward to monitor the IO costs. On my system, fully loading a PfsCalibrated file takes about 5 seconds and loading a single spectrum takes 4 seconds with cold buffers. Loading it again takes 5 seconds vs 1 seconds so filtering the spectra should have some benefit and reduces the memory footprint. The GA pipeline processes the data object by object and has to load 12-24 exposures, so being able to load a single spectrum from PfsCalibrated files is important.

I added a small test script under `./bin` to compare the system metrics.