### PR TITLE
DAMD-195 Add targetValidationMask to pfsConfig

### DIFF
--- a/python/pfs/datamodel/convergenceParams.py
+++ b/python/pfs/datamodel/convergenceParams.py
@@ -1,0 +1,91 @@
+class ConvergenceParams:
+    """Fixed mapping between convergence parameter names and FITS header cards.
+
+    Everything fps records about one convergence, written once and read by both the FITS
+    header and the opdb ingest, so the file and the database cannot disagree about how a
+    visit was converged.
+
+    distanceTolerance is the one a reader cannot do without: GOOD means
+    |pfiCenter - pfiNominal| <= that value, and it varies per visit.  The rest is
+    provenance -- what was asked for, and how it went.
+
+    Note the two tolerances are different numbers.  requestedTolerance is what the
+    convergence loop aimed for per iteration; distanceTolerance is the threshold that
+    decides fiberStatus, and is floored well above it.
+
+    Values keep their type through a round trip, unlike VersionTable which stringifies:
+    a tolerance is a float and a skipped check is a bool.
+    """
+
+    _table = (
+        ("targetFallbackInvalid", "W_CVFBI", str,
+         "where an invalid target is sent"),
+        ("targetFallbackUnassigned", "W_CVFBU", str,
+         "where an unassigned cobra is sent"),
+        ("distanceTolerance", "W_CVTOL", float,
+         "[mm] fiberStatus=GOOD if <= distanceTolerance"),
+        ("fiducialCheckSkipped", "W_CVSKF", bool,
+         "fiducial interference check was skipped"),
+        ("numIterations", "W_CVNIT", int,
+         "iterations allocated to the convergence"),
+        ("elapsedTime", "W_CVETM", float,
+         "[s] elapsed time of the convergence"),
+        ("requestedTolerance", "W_CVRTL", float,
+         "[mm] tolerance for the convergence loop"),
+    )
+
+    @classmethod
+    def getFieldNames(cls):
+        """Return the declared parameter names.
+
+        Returns
+        -------
+        `tuple` of `str`
+            Names in table order: the only keys `read` reports and `write` records.
+        """
+        return tuple(keyName for keyName, _, _, _ in cls._table)
+
+    @classmethod
+    def read(cls, header):
+        """Read the convergence parameters from a FITS header.
+
+        Parameters
+        ----------
+        header : `astropy.io.fits.Header`
+            Primary header.
+
+        Returns
+        -------
+        dict
+            Only the keys actually present; absent ones are simply not reported, so a
+            file written before a parameter existed does not claim a default it never
+            used.
+        """
+        info = {}
+        for keyName, card, cast, _ in cls._table:
+            if card in header:
+                info[keyName] = cast(header[card])
+
+        return info
+
+    @classmethod
+    def write(cls, header, info):
+        """Write the convergence parameters to a FITS header.
+
+        Cards in the table are cleared first, so a re-write cannot leave a stale value
+        behind.  A key absent from `info` writes no card.
+
+        Parameters
+        ----------
+        header : `astropy.io.fits.Header`
+            Primary header; modified.
+        info : dict
+            Convergence parameters, keyed as in the table.
+        """
+        for _, card, _, _ in cls._table:
+            if card in header:
+                del header[card]
+
+        for keyName, card, cast, comment in cls._table:
+            if info.get(keyName) is not None:
+                header[card] = (cast(info[keyName]), comment)

--- a/python/pfs/datamodel/pfsConfig.py
+++ b/python/pfs/datamodel/pfsConfig.py
@@ -9,6 +9,7 @@ from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 from pfs.datamodel.utils import convertToIso8601Utc
+from pfs.datamodel.convergenceParams import ConvergenceParams
 from pfs.datamodel.versionTable import VersionTable
 
 try:
@@ -34,6 +35,10 @@ __all__ = (
     "checkPfsConfigHeader",
     "InstrumentStatusFlag",
     "InstrumentStatusDescription",
+    "TargetValidation",
+    "TargetValidationDescription",
+    "CobraCommand",
+    "CobraCommandDescription",
 )
 
 
@@ -192,6 +197,82 @@ class InstrumentStatusFlag(enum.IntFlag, **metaclassParams):
     INSROT_MISMATCH = 1 << 0
     CONVERGENCE_FAILED = 1 << 1
     CONVERGENCE_SKIPPED = 1 << 2
+
+
+@verify
+class TargetValidation(enum.IntFlag, **metaclassParams):
+    """Bit positions for why FPS refused to send a cobra to its design target.
+
+    Set only where there was a target to validate, i.e. ``targetType`` in
+    (SCIENCE, SKY, FLUXSTD); zero elsewhere.  Every bit is geometric, so a non-zero
+    value means "this cobra was designed to converge, and FPS refused it", and
+    ``count(targetValidationMask != 0)`` is the number of science targets lost to
+    instrument geometry.  What FPS did with the cobra afterwards is `CobraCommand`.
+
+    A rejected target is never sent to its nominal position, so it can never be
+    within convergence tolerance: ``fiberStatus == GOOD`` implies a zero mask.
+    The field is therefore purely diagnostic and no existing selection changes.
+
+    NOT_SET marks a pfsConfig written before DAMD_VER 6, where the verdict was
+    never recorded.  It is distinct from zero on purpose -- zero asserts that
+    every target was accepted, which such a file cannot claim.
+    """
+    NOT_FINITE = 1 << 0
+    TOO_CLOSE_TO_CENTER = 1 << 1
+    TOO_FAR_FROM_CENTER = 1 << 2
+    FIDUCIAL_INTERFERENCE = 1 << 3
+    NOT_SET = 1 << 15
+
+
+# Separate dictionary for descriptions (must be outside the class)
+TargetValidationDescription = {
+    TargetValidation.NOT_FINITE:
+        "the design gave no position for a target that was meant to be observed",
+    TargetValidation.TOO_CLOSE_TO_CENTER:
+        "target lies inside the cobra's minimum reach",
+    TargetValidation.TOO_FAR_FROM_CENTER:
+        "target lies beyond the cobra's maximum reach",
+    TargetValidation.FIDUCIAL_INTERFERENCE:
+        "the cobra arm would interfere with a fiducial fiber",
+    TargetValidation.NOT_SET:
+        "no target validation was recorded; the file predates DAMD_VER 6",
+}
+
+
+class CobraCommand(enum.IntEnum, **metaclassParams):
+    """What FPS did with a cobra for this visit.
+
+    Exclusive and exhaustive over the cobras: every one is driven to its design
+    target, driven home, parked on its black dot, or left alone.  Separate from
+    `TargetValidation`, which judges the target rather than recording the action, so
+    a cobra can carry a clean validation and still not have been commanded.
+
+    NOT_COMMANDED is zero: FPS did not move this cobra, whether because the operator
+    excluded it, because it is broken, or because the fiber has no cobra at all.  So
+    a non-zero value means exactly "FPS commanded this cobra, and here is where to".
+
+    NOT_SET is only for a pfsConfig written before DAMD_VER 6, which cannot claim that
+    nothing was commanded.  It is never written for a new file.
+    """
+    NOT_COMMANDED = 0
+    CONVERGE = 1
+    HOME = 2
+    BLACK_DOT = 3
+    NOT_SET = 4
+
+
+CobraCommandDescription = {
+    CobraCommand.NOT_COMMANDED:
+        "left where it was: excluded by the operator, broken, or not a cobra at all",
+    CobraCommand.CONVERGE:
+        "driven to its design target",
+    CobraCommand.HOME:
+        "driven to its hard stop",
+    CobraCommand.BLACK_DOT:
+        "parked on its black dot",
+    CobraCommand.NOT_SET:
+        "no command was recorded; the file predates DAMD_VER 6",
+}
 
 
 # Separate dictionary for descriptions (must be outside the class)
@@ -502,9 +583,9 @@ class PfsDesign:
 
         Parameters
         ----------
-        logical : `numpy.ndarray` of `bool`
-            Boolean array (of same length as ``self``) indicating which fibers
-            to select.
+        logical : `numpy.ndarray` of `bool` or `int`
+            Boolean array (of same length as ``self``) indicating which fibers to
+            select, or an array of indices, which also sets the order of the result.
 
         Returns
         -------
@@ -512,14 +593,15 @@ class PfsDesign:
             A new ``PfsDesign`` or ``PfsConfig`` containing only the selected
             fibers.
         """
-        numOriginal = len(self)
+        logical = np.asarray(logical)
+        indices = np.flatnonzero(logical) if logical.dtype == bool else logical
         kwargs = {name: getattr(self, name) for name in self._scalars}
         for name in self._keywords + ["fiberStatus"]:
             array = getattr(self, name)
             if isinstance(array, np.ndarray):
-                subArray = array[logical]
+                subArray = array[indices]
             else:
-                subArray = [array[ii] for ii in range(numOriginal) if logical[ii]]
+                subArray = [array[ii] for ii in indices]
             kwargs[name] = subArray
         new = type(self)(**kwargs)
         new.isSubset = True
@@ -739,7 +821,7 @@ class PfsDesign:
         header["POSANG"] = (self.posAng, "[degree] PFI position angle")
         header["ARMS"] = (self.arms, "Exposed arms")
         header["DSGN_NAM"] = (self.designName, "Name of design")
-        header["DAMD_VER"] = (5, "PfsDesign/PfsConfig datamodel version")
+        header["DAMD_VER"] = (6, "PfsDesign/PfsConfig datamodel version")
         header["W_PFDSGN"] = (self.pfsDesignId, "Identifier for fiber configuration")
         header["VARIANT"] = (self.variant, "Which variant of PFDSGN0 we are.")
         header["PFDSGN0"] = (self.designId0, "The base design of which we are a variant")
@@ -807,7 +889,9 @@ class PfsDesign:
                 # skip astrometry and operation keywords as they have already been set
                 if (nn not in cls._astrometry) and (nn not in cls._operation):
                     assert nn not in kwargs
-                    if nn in ['cobraId', 'cobraTheta', 'cobraPhi'] and nn not in data.columns.names:
+                    if (nn in ['cobraId', 'cobraTheta', 'cobraPhi', 'targetValidationMask',
+                               'cobraCommand']
+                            and nn not in data.columns.names):
                         kwargs[nn] = None
                     else:
                         kwargs[nn] = data[nn]
@@ -1390,19 +1474,31 @@ class PfsConfig(PfsDesign):
         Bitmask indicating instrument-related status flags for this visit.
     visit0 : `int`, optional
         visitId used for the convergence.
+    convergenceParams : `dict`, optional
+        Parameters the convergence ran under, so the per-fiber columns can be
+        reproduced rather than merely read.  See `ConvergenceParams` for the keys.
     cobraId : `numpy.ndarray` of `int32`, optional
         Cobra identifier for each fiber.
     cobraTheta : `numpy.ndarray` of `float32`
         Theta angle for each cobra, degrees.
     cobraPhi : `numpy.ndarray` of `float32`
         Phi angle for each cobra, degrees.
+    targetValidationMask : `numpy.ndarray` of `int32`, optional
+        `TargetValidation` bitmask per fiber: why FPS refused to send the cobra
+        to its design target, or zero if it was accepted.  Defaults to
+        `TargetValidation.NOT_SET` when unknown, which is how a pfsConfig
+        written before DAMD_VER 6 reads.
+    cobraCommand : `numpy.ndarray` of `int32`, optional
+        `CobraCommand` per fiber: what FPS did with the cobra.  Defaults to
+        `CobraCommand.NOT_SET`, which is how a fiber with no cobra reads, and how a
+        pfsConfig written before DAMD_VER 6 reads throughout.
     """
     # Scalar values
     _scalars = ["pfsDesignId", "designName",
                 "visit", "raBoresight", "decBoresight", "posAng", "arms", "guideStars",
                 "variant", "designId0", "obstime", "obstimeDesign",
                 "versionsDesign", "versions0", "versions",
-                "header", "camMask", "instStatusFlag", "visit0"]
+                "header", "camMask", "instStatusFlag", "visit0", "convergenceParams"]
 
     # List of fields required, and their FITS type
     # Some elements of the code expect the following to be present:
@@ -1427,6 +1523,8 @@ class PfsConfig(PfsDesign):
                "pfiCenter": "2E",
                "cobraTheta": "E",
                "cobraPhi": "E",
+               "targetValidationMask": "J",
+               "cobraCommand": "J",
                }
     _pointFields = ["pfiNominal", "pfiCenter"]  # List of point fields; should be in _fields too
     _photometry = ["fiberFlux",
@@ -1470,8 +1568,15 @@ class PfsConfig(PfsDesign):
                  visit0=None,
                  cobraId=None,
                  cobraTheta=None,
-                 cobraPhi=None):
+                 cobraPhi=None,
+                 targetValidationMask=None,
+                 cobraCommand=None,
+                 convergenceParams=None):
 
+        if targetValidationMask is None:
+            targetValidationMask = np.full(len(fiberId), int(TargetValidation.NOT_SET), dtype=np.int32)
+        if cobraCommand is None:
+            cobraCommand = np.full(len(fiberId), int(CobraCommand.NOT_SET), dtype=np.int32)
         if cobraTheta is None:
             cobraTheta = np.full(len(fiberId), np.nan, dtype=np.float32)
         if cobraPhi is None:
@@ -1481,8 +1586,11 @@ class PfsConfig(PfsDesign):
         self.pfiCenter = np.array(pfiCenter)
         self.cobraTheta = np.asarray(cobraTheta, dtype=np.float32)
         self.cobraPhi = np.asarray(cobraPhi, dtype=np.float32)
+        self.targetValidationMask = np.asarray(targetValidationMask, dtype=np.int32)
+        self.cobraCommand = np.asarray(cobraCommand, dtype=np.int32)
         self.camMask = camMask
         self.instStatusFlag = instStatusFlag
+        self.convergenceParams = dict() if convergenceParams is None else dict(convergenceParams)
         self.obstimeDesign = convertToIso8601Utc(obstimeDesign) if obstimeDesign else None
         self.visit0 = visit0
         versionsDesign = dict() if versionsDesign is None else dict(versionsDesign)
@@ -1522,9 +1630,37 @@ class PfsConfig(PfsDesign):
         """Usual filename"""
         return self.fileNameFormat % (self.pfsDesignId, self.visit)
 
+    def cobraConfig(self, sortBy="cobraId"):
+        """Return the subset of fibers that a cobra positions.
+
+        cobraTheta, cobraPhi, targetValidationMask and cobraCommand describe a cobra,
+        so on a fiber that has none they can only say "not applicable".  Selecting the
+        cobras first removes that case instead of asking every column to encode it, and
+        leaves each of them meaningful for every row.
+
+        Parameters
+        ----------
+        sortBy : `str`, optional
+            Column to order the result by.  "cobraId" makes row i cobra i + 1, lining
+            the result up with anything indexed by cobra; "fiberId" keeps the ordering
+            the rest of the file uses.
+
+        Returns
+        -------
+        `PfsConfig`
+            Containing only the fibers a cobra positions, i.e. every targetType but
+            ENGINEERING.
+        """
+        if sortBy not in ("cobraId", "fiberId"):
+            raise ValueError(f"sortBy must be 'cobraId' or 'fiberId', got {sortBy!r}")
+
+        onCobra = np.flatnonzero(self.targetType != TargetType.ENGINEERING)
+        return self[onCobra[np.argsort(getattr(self, sortBy)[onCobra])]]
+
     @classmethod
     def fromPfsDesign(cls, pfsDesign, visit, pfiCenter, header=None, camMask=0, instStatusFlag=0,
-                      visit0=None, cobraTheta=None, cobraPhi=None, versions=None, versions0=None):
+                      visit0=None, cobraTheta=None, cobraPhi=None, versions=None, versions0=None,
+                      targetValidationMask=None, cobraCommand=None, convergenceParams=None):
         """Construct from a ``PfsDesign``
 
         Parameters
@@ -1547,6 +1683,16 @@ class PfsConfig(PfsDesign):
             Theta angle for each cobra, degrees.
         cobraPhi : `numpy.ndarray` of `float32`, optional
             Phi angle for each cobra, degrees.
+        targetValidationMask : `numpy.ndarray` of `int32`, optional
+            `TargetValidation` bitmask per fiber.  A design carries no verdict, so
+            omitting it leaves every fiber `TargetValidation.NOT_SET` until FPS
+            validates the targets at move time.
+        cobraCommand : `numpy.ndarray` of `int32`, optional
+            `CobraCommand` per fiber.  A design commands nothing, so omitting it leaves
+            every fiber `CobraCommand.NOT_SET`.
+        convergenceParams : `dict`, optional
+            How the visit was converged, keyed as in `ConvergenceParams`.  Empty until
+            the convergence has run, since it records the outcome as well as the policy.
 
         Returns
         -------
@@ -1567,11 +1713,14 @@ class PfsConfig(PfsDesign):
         kwargs["visit0"] = visit0
         kwargs["cobraTheta"] = cobraTheta
         kwargs["cobraPhi"] = cobraPhi
+        kwargs["targetValidationMask"] = targetValidationMask
+        kwargs["cobraCommand"] = cobraCommand
         kwargs["versionsDesign"] = dict(pfsDesign.versions)
         versions = dict() if versions is None else dict(versions)
         versions0 = dict() if versions0 is None else dict(versions0)
         kwargs["versions"] = versions
         kwargs["versions0"] = versions0
+        kwargs["convergenceParams"] = dict() if convergenceParams is None else dict(convergenceParams)
 
         return PfsConfig(**kwargs)
 
@@ -1601,6 +1750,7 @@ class PfsConfig(PfsDesign):
         kwargs["camMask"] = header.get("W_CAMMSK", 0)
         kwargs["instStatusFlag"] = header.get("W_INSMSK", 0)
         kwargs["obstimeDesign"] = header.get("W_DSOBS0", None)
+        kwargs["convergenceParams"] = ConvergenceParams.read(header)
 
         if visit is not None:
             if "visit" in kwargs and kwargs["visit"] != visit:
@@ -1636,6 +1786,7 @@ class PfsConfig(PfsDesign):
         super()._writeHeader(header)
         header["W_VISIT"] = (self.visit, "Visit number")
         header["W_CAMMSK"] = (self.camMask, "Bitmask describing which camera was used for this visit.")
+        ConvergenceParams.write(header, self.convergenceParams)
         header["W_INSMSK"] = (self.instStatusFlag,
                               "Bitmask indicating instrument-related status flags for this visit.")
 

--- a/tests/test_PfsConfig.py
+++ b/tests/test_PfsConfig.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import sys
+import tempfile
 import unittest
 
 import astropy.io.fits as pyfits
@@ -10,7 +11,7 @@ import lsst.utils.tests
 import numpy as np
 from pfs.datamodel.pfsConfig import (
     PfsConfig, TargetType, FiberStatus, PfsDesign, GuideStars, InstrumentStatusFlag,
-    InstrumentStatusDescription)
+    InstrumentStatusDescription, TargetValidation, CobraCommand)
 from pfs.datamodel.utils import convertToIso8601Utc
 
 display = None
@@ -130,6 +131,16 @@ class PfsConfigTestCase(lsst.utils.tests.TestCase):
 
         self.obstime = convertToIso8601Utc(datetime.datetime.now(datetime.timezone.utc).isoformat())
         self.obstimeDesign = convertToIso8601Utc(datetime.datetime.now(datetime.timezone.utc).isoformat())
+        self.cobraCommand = np.full(self.numFibers, int(CobraCommand.CONVERGE))
+        self.cobraCommand[::37] = int(CobraCommand.NOT_COMMANDED)
+        self.cobraCommand[::53] = int(CobraCommand.BLACK_DOT)
+        self.convergenceParams = dict(targetFallbackInvalid="BLACKSPOT",
+                                      targetFallbackUnassigned="BLACKSPOT",
+                                      distanceTolerance=0.05,
+                                      fiducialCheckSkipped=False,
+                                      numIterations=8,
+                                      elapsedTime=79.55,
+                                      requestedTolerance=0.01)
         self.versions = dict(ics_iicActor="2.7.17", pfs_utils="w.2026.09", datamodel="w.2026.09")
         self.versions0 = dict(ics_fpsActor="1.8.10", pfs_utils="w.2026.09", datamodel="w.2026.09")
         self.versionsDesign = dict(pfs_utils="w.2026.09", datamodel="w.2026.09")
@@ -137,6 +148,13 @@ class PfsConfigTestCase(lsst.utils.tests.TestCase):
         self.visit0 = 67889
         self.cobraTheta = np.full(len(self.fiberId), 0.0)
         self.cobraPhi = np.full(len(self.fiberId), 0.0)
+
+        self.targetValidationMask = np.zeros(len(self.fiberId), dtype=np.int32)
+        self.targetValidationMask[1] = TargetValidation.FIDUCIAL_INTERFERENCE
+        self.targetValidationMask[2] = TargetValidation.NOT_FINITE
+        # co-occurring reasons must survive as a bitmask, not collapse to one
+        self.targetValidationMask[3] = (TargetValidation.TOO_FAR_FROM_CENTER
+                                        | TargetValidation.FIDUCIAL_INTERFERENCE)
 
     def _makeInstance(self, Class, **kwargs):
         """Construct a PfsDesign or PfsConfig using default values
@@ -220,6 +238,9 @@ class PfsConfigTestCase(lsst.utils.tests.TestCase):
     def assertPfsConfig(self, lhs, rhs):
         self.assertEqual(lhs.visit, rhs.visit)
         np.testing.assert_array_equal(lhs.pfiCenter, rhs.pfiCenter)
+        np.testing.assert_array_equal(lhs.targetValidationMask, rhs.targetValidationMask)
+        np.testing.assert_array_equal(lhs.cobraCommand, rhs.cobraCommand)
+        self.assertEqual(lhs.convergenceParams, rhs.convergenceParams)
         self.assertEqual(lhs.versionsDesign, rhs.versionsDesign)
         self.assertEqual(lhs.versions0, rhs.versions0)
         self.assertEqual(lhs.versions, rhs.versions)
@@ -244,6 +265,94 @@ class PfsConfigTestCase(lsst.utils.tests.TestCase):
             raise  # Leave file for manual inspection
         else:
             os.unlink(filename)
+
+    def testTargetValidationMask(self):
+        """Test targetValidationMask, including files written before it existed"""
+        config = self.makePfsConfig()
+        self.assertEqual(config.targetValidationMask.dtype, np.int32)
+        # setUp supplies a mask, so nothing may read as "never recorded"
+        self.assertTrue(np.all(config.targetValidationMask != TargetValidation.NOT_SET))
+
+        # Self-contained: this test shares a filename with the others, so writing into
+        # the common directory races with them when the suite runs in parallel.
+        with tempfile.TemporaryDirectory() as dirName:
+            config.write(dirName=dirName)
+            filename = os.path.join(dirName, config.filename)
+
+            other = PfsConfig.read(self.pfsDesignId, self.visit, dirName=dirName)
+            np.testing.assert_array_equal(other.targetValidationMask, self.targetValidationMask)
+
+            # Strip the column, as a pfsConfig written before DAMD_VER 6.  Reading it must
+            # not raise, and must report NOT_SET rather than zero -- zero would assert that
+            # every target was accepted, which such a file cannot claim.  The stripped copy
+            # goes to its own directory: writing over a file that is still open truncates it.
+            with tempfile.TemporaryDirectory() as legacyDir:
+                with pyfits.open(filename) as fd:
+                    columns = [col for col in fd["CONFIG"].columns
+                               if col.name != "targetValidationMask"]
+                    hdus = pyfits.HDUList(
+                        [pyfits.BinTableHDU.from_columns(columns, fd["CONFIG"].header, name="CONFIG")
+                         if hdu.name == "CONFIG" else hdu.copy() for hdu in fd])
+                    hdus[0].header["DAMD_VER"] = 5
+                hdus.writeto(os.path.join(legacyDir, config.filename))
+
+                old = PfsConfig.read(self.pfsDesignId, self.visit, dirName=legacyDir)
+                self.assertTrue(np.all(old.targetValidationMask == TargetValidation.NOT_SET))
+                os.unlink(os.path.join(legacyDir, config.filename))
+                old.write(dirName=legacyDir)  # and remains writable
+
+    def testCobraCommand(self):
+        """Test cobraCommand and the cobraConfig subset"""
+        config = self.makePfsConfig()
+        self.assertEqual(config.cobraCommand.dtype, np.int32)
+        # setUp supplies a command, so nothing may read as "never recorded"
+        self.assertTrue(np.all(config.cobraCommand != CobraCommand.NOT_SET))
+
+        with tempfile.TemporaryDirectory() as dirName:
+            config.write(dirName=dirName)
+            filename = os.path.join(dirName, config.filename)
+
+            other = PfsConfig.read(self.pfsDesignId, self.visit, dirName=dirName)
+            np.testing.assert_array_equal(other.cobraCommand, self.cobraCommand)
+
+            # As a pfsConfig written before DAMD_VER 6: NOT_SET rather than zero, since
+            # zero is NOT_COMMANDED and would assert that fps moved nothing.
+            with tempfile.TemporaryDirectory() as legacyDir:
+                with pyfits.open(filename) as fd:
+                    columns = [col for col in fd["CONFIG"].columns if col.name != "cobraCommand"]
+                    hdus = pyfits.HDUList(
+                        [pyfits.BinTableHDU.from_columns(columns, fd["CONFIG"].header, name="CONFIG")
+                         if hdu.name == "CONFIG" else hdu.copy() for hdu in fd])
+                    hdus[0].header["DAMD_VER"] = 5
+                hdus.writeto(os.path.join(legacyDir, config.filename))
+
+                old = PfsConfig.read(self.pfsDesignId, self.visit, dirName=legacyDir)
+                self.assertTrue(np.all(old.cobraCommand == CobraCommand.NOT_SET))
+
+    def testCobraConfig(self):
+        """Test the cobraConfig subset and its ordering"""
+        config = self.makePfsConfig()
+        onCobra = config.targetType != TargetType.ENGINEERING
+
+        for sortBy, column in (("cobraId", "cobraId"), ("fiberId", "fiberId")):
+            sub = config.cobraConfig(sortBy=sortBy)
+            self.assertEqual(len(sub), int(onCobra.sum()))
+            self.assertTrue(np.all(sub.targetType != TargetType.ENGINEERING))
+            # ordering is the point of the argument
+            self.assertTrue(np.all(np.diff(getattr(sub, column)) > 0))
+            # every fiber survives, whichever order it comes back in
+            self.assertEqual(set(sub.fiberId.tolist()), set(config.fiberId[onCobra].tolist()))
+
+        # the reorder must carry the list-valued columns too, not just the arrays
+        sub = config.cobraConfig()
+        order = np.flatnonzero(onCobra)
+        order = order[np.argsort(config.cobraId[order])]
+        np.testing.assert_array_equal(sub.fiberId, config.fiberId[order])
+        np.testing.assert_array_equal(np.asarray(sub.patch),
+                                      np.asarray([config.patch[ii] for ii in order]))
+
+        with self.assertRaises(ValueError):
+            config.cobraConfig(sortBy="nonsense")
 
     def testBadCtor(self):
         """Test bad constructor calls"""
@@ -322,8 +431,18 @@ class PfsConfigTestCase(lsst.utils.tests.TestCase):
         config = self.makePfsConfig()
         built = PfsConfig.fromPfsDesign(design, self.visit, self.pfiCenter,
                                         versions=self.versions,
-                                        versions0=self.versions0)
+                                        versions0=self.versions0,
+                                        targetValidationMask=self.targetValidationMask,
+                                        cobraCommand=self.cobraCommand,
+                                        convergenceParams=self.convergenceParams)
         self.assertPfsConfig(built, config)
+
+        # A design carries no verdict, so omitting the mask must leave it unrecorded
+        # rather than claiming every target was accepted.
+        unvalidated = PfsConfig.fromPfsDesign(design, self.visit, self.pfiCenter,
+                                              versions=self.versions,
+                                              versions0=self.versions0)
+        self.assertTrue(np.all(unvalidated.targetValidationMask == TargetValidation.NOT_SET))
 
     def testDesignName(self):
         """Test creation of design name"""

--- a/versions.txt
+++ b/versions.txt
@@ -20,6 +20,10 @@ PfsDesign, and so their versions are incremented together.
 * 1: Initial version.
 * 2: Additional HDU added for guide star information, provided by ETS shuffle.
 * 3: Write pfsDesignId and visit0 in header.
+* 6: targetValidationMask and cobraCommand columns added to PfsConfig, recording
+     why FPS refused to send a cobra to its design target and what it did with the
+     cobra instead. Absent in earlier files, which read back as
+     TargetValidation.NOT_SET and CobraCommand.NOT_SET.
 
 
 PfsDetectorMap


### PR DESCRIPTION
Records why FPS refused to send a cobra to its design target, so a pfsConfig can report how many science targets were lost to instrument geometry without reading FPS data directories.  Set only where there was a target to validate, so non-zero means the cobra was designed to converge and was refused.

Nothing existing changes.  A rejected target is never sent to its nominal position and so can never be within convergence tolerance: fiberStatus GOOD implies a zero mask, and the column is purely diagnostic.

Files written before this read back as NOT_SET rather than zero, which would otherwise assert that every target was accepted.  DAMD_VER 5 -> 6.